### PR TITLE
Use UNUserNotificationCenter instead of deprecated UIUserNotificationSettings on iOS 10+ 

### DIFF
--- a/ios/Classes/FlutterAppBadgerPlugin.m
+++ b/ios/Classes/FlutterAppBadgerPlugin.m
@@ -12,7 +12,6 @@
 - (void)enableNotifications {
     if (@available(iOS 10, *)) {
         UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
-        center.delegate = self;
         [center requestAuthorizationWithOptions:(UNAuthorizationOptionAlert | UNAuthorizationOptionBadge | UNAuthorizationOptionSound) completionHandler:^(BOOL granted, NSError * _Nullable error){}];
     } else {
         UIUserNotificationSettings* notificationSettings = [UIUserNotificationSettings settingsForTypes:UIUserNotificationTypeAlert | UIUserNotificationTypeBadge | UIUserNotificationTypeSound categories:nil];

--- a/ios/Classes/FlutterAppBadgerPlugin.m
+++ b/ios/Classes/FlutterAppBadgerPlugin.m
@@ -10,9 +10,15 @@
 }
 
 - (void)enableNotifications {
-    UIUserNotificationSettings* notificationSettings = [UIUserNotificationSettings settingsForTypes:UIUserNotificationTypeAlert | UIUserNotificationTypeBadge | UIUserNotificationTypeSound categories:nil];
-    
-    [[UIApplication sharedApplication] registerUserNotificationSettings:notificationSettings];
+    if (@available(iOS 10, *)) {
+        UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
+        center.delegate = self;
+        [center requestAuthorizationWithOptions:(UNAuthorizationOptionAlert | UNAuthorizationOptionBadge | UNAuthorizationOptionSound) completionHandler:^(BOOL granted, NSError * _Nullable error){}];
+    } else {
+        UIUserNotificationSettings* notificationSettings = [UIUserNotificationSettings settingsForTypes:UIUserNotificationTypeAlert | UIUserNotificationTypeBadge | UIUserNotificationTypeSound categories:nil];
+        
+        [[UIApplication sharedApplication] registerUserNotificationSettings:notificationSettings];
+    }
 }
 
 - (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result {


### PR DESCRIPTION
UIUserNotificationSettings is deprecated since iOS 10 ([screenshot of issues from Xcode](https://user-images.githubusercontent.com/31893391/127520617-61d68f6d-eb12-4159-8bfd-f714da2e2373.png))

In this PR I replaced it with the new APIs for iOS 10+.