### PR TITLE
Don't overwrite categories

### DIFF
--- a/ios/Classes/FlutterAppBadgerPlugin.m
+++ b/ios/Classes/FlutterAppBadgerPlugin.m
@@ -14,8 +14,7 @@
         UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
         [center requestAuthorizationWithOptions:(UNAuthorizationOptionAlert | UNAuthorizationOptionBadge | UNAuthorizationOptionSound) completionHandler:^(BOOL granted, NSError * _Nullable error){}];
     } else {
-        UIUserNotificationSettings* notificationSettings = [UIUserNotificationSettings settingsForTypes:UIUserNotificationTypeAlert | UIUserNotificationTypeBadge | UIUserNotificationTypeSound categories:nil];
-        
+        UIUserNotificationSettings* notificationSettings = [UIUserNotificationSettings settingsForTypes:UIUserNotificationTypeAlert | UIUserNotificationTypeBadge | UIUserNotificationTypeSound categories:[[UIApplication sharedApplication] currentUserNotificationSettings].categories];
         [[UIApplication sharedApplication] registerUserNotificationSettings:notificationSettings];
     }
 }


### PR DESCRIPTION
## Abstract 
Use the current settings for categories in the library that have been unintentionally overwritten by nil
Actually, in my app don't work push notification actionable button after called flutter app badger removeBadge.

### Question
Why calling enableNotifications on `handleMethodCall` ?
It's strange to ask for permission for notifications that an app can only ask once in FlutterAppBadger. I was also curious about the reason for overwriting the settings.
