### PR TITLE
Updated android gradle plugin (namespace) and compileSdk version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,3 +1,5 @@
+package android
+
 group 'fr.g123k.flutterappbadge.flutterappbadger'
 version '1.0-SNAPSHOT'
 
@@ -22,7 +24,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 29
+    compileSdk 34
 
     defaultConfig {
         minSdkVersion 16

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,1 +1,3 @@
+package android
+
 rootProject.name = 'flutter_app_badger'

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="fr.g123k.flutterappbadge.flutterappbadger">
-</manifest>
+<manifest package="fr.g123k.flutterappbadge.flutterappbadger" />

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -15,17 +15,16 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 29
+    compileSdk 34
 
     lintOptions {
         disable 'InvalidPackage'
     }
 
     defaultConfig {
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "fr.g123k.flutterappbadger.flutterappbadgerexample"
         minSdkVersion 16
-        targetSdkVersion 29
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -37,6 +36,10 @@ android {
             // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig signingConfigs.debug
         }
+    }
+
+    if (project.android.hasProperty('namespace')) {
+        namespace 'fr.g123k.flutterappbadge.flutterappbadger'
     }
 }
 

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,3 +1,5 @@
+package example.android
+
 buildscript {
     repositories {
         google()

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -54,13 +54,13 @@ class _MyAppState extends State<MyApp> {
             crossAxisAlignment: CrossAxisAlignment.center,
             children: <Widget>[
               new Text('Badge supported: $_appBadgeSupported\n'),
-              new RaisedButton(
+              new MaterialButton(
                 child: new Text('Add badge'),
                 onPressed: () {
                   _addBadge();
                 },
               ),
-              new RaisedButton(
+              new MaterialButton(
                   child: new Text('Remove badge'),
                   onPressed: () {
                     _removeBadge();


### PR DESCRIPTION
Resolved namespace incompatibility issue in build.gradle in app module. Error in the image below. And updated the package build version to the latest android version.

![app_badger](https://github.com/g123k/flutter_app_badger/assets/27814206/11f04b06-fb2d-4e36-acda-2f68ce408229)
