### PR TITLE
Support iOS 17 setBadgeCount method (starting from iOS 16)

### DIFF
--- a/ios/Classes/FlutterAppBadgerPlugin.m
+++ b/ios/Classes/FlutterAppBadgerPlugin.m
@@ -1,4 +1,5 @@
 #import "FlutterAppBadgerPlugin.h"
+#import <UserNotifications/UserNotifications.h>
 
 @implementation FlutterAppBadgerPlugin
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
@@ -21,20 +22,28 @@
 
 - (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result {
     [self enableNotifications];
-    
-  if ([@"updateBadgeCount" isEqualToString:call.method]) {
-      NSDictionary *args = call.arguments;
-      NSNumber *count = [args objectForKey:@"count"];
-      [UIApplication sharedApplication].applicationIconBadgeNumber = count.integerValue;
-    result(nil);
-  } else if ([@"removeBadge" isEqualToString:call.method]) {
-      [UIApplication sharedApplication].applicationIconBadgeNumber = 0;
-      result(nil);
-  } else if ([@"isAppBadgeSupported" isEqualToString:call.method]) {
-      result(@YES);
-  } else {
-    result(FlutterMethodNotImplemented);
-  }
+        
+    if ([@"updateBadgeCount" isEqualToString:call.method]) {
+        NSDictionary *args = call.arguments;
+        NSNumber *count = [args objectForKey:@"count"];
+        if (@available(iOS 16, *)) {
+            [[UNUserNotificationCenter currentNotificationCenter] setBadgeCount:count.integerValue withCompletionHandler:^(NSError * _Nullable error) {}];
+        } else {
+            [UIApplication sharedApplication].applicationIconBadgeNumber = count.integerValue;
+        }
+        result(nil);
+    } else if ([@"removeBadge" isEqualToString:call.method]) {
+        if (@available(iOS 16, *)) {
+            [[UNUserNotificationCenter currentNotificationCenter] setBadgeCount:0 withCompletionHandler:^(NSError * _Nullable error) {}];
+        } else {
+            [UIApplication sharedApplication].applicationIconBadgeNumber = 0;
+        }
+        result(nil);
+    } else if ([@"isAppBadgeSupported" isEqualToString:call.method]) {
+        result(@YES);
+    } else {
+        result(FlutterMethodNotImplemented);
+    }
 }
 
 @end


### PR DESCRIPTION
Needs testing on iOS 16 – as per [the docs](https://developer.apple.com/documentation/usernotifications/unusernotificationcenter/4031317-setbadgecount?language=objc) it is supported, but I haven't had a chance to verify it.

Separately, it's possible that the import (2nd line) is not necessary but I'm not that familiar with ObjC so feel free to remove it if it's redundant.