### PR TITLE
Add iOS privacy info

### DIFF
--- a/ios/PrivacyInfo.xcprivacy
+++ b/ios/PrivacyInfo.xcprivacy
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict/>
+	</array>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict/>
+	</array>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>

--- a/ios/flutter_app_badger.podspec
+++ b/ios/flutter_app_badger.podspec
@@ -17,5 +17,6 @@ Pod::Spec.new do |s|
   s.dependency 'Flutter'
   
   s.ios.deployment_target = '8.0'
+  s.resource_bundles = {'flutter_app_badger_privacy' => ['PrivacyInfo.xcprivacy']}
 end
 


### PR DESCRIPTION
Add PrivacyInfo to podspec of flutter_app_badger.

By Apple's guidelines, you must add an empty file even if you are not collecting anything.
ref: https://developer.apple.com/documentation/bundleresources/privacy_manifest_files

I think `flutter_app_bader` doesn't collect anything, so I created an empty file.