### PR TITLE
[feature] Separate method call for enable notifications

### DIFF
--- a/ios/Classes/FlutterAppBadgerPlugin.m
+++ b/ios/Classes/FlutterAppBadgerPlugin.m
@@ -21,7 +21,7 @@
 }
 
 - (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result {
-    if([@"enableNotifications" isEqualToString:call.method) {
+    if([@"enableNotifications" isEqualToString:call.method]) {
         NSDictionary *args = call.arguments;
         NSNumber *enableNotifications = [args objectForKey:@"enableNotifications"];
 

--- a/ios/Classes/FlutterAppBadgerPlugin.m
+++ b/ios/Classes/FlutterAppBadgerPlugin.m
@@ -21,11 +21,18 @@
 }
 
 - (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result {
-    [self enableNotifications];
-        
+    if([@"enableNotifications" isEqualToString:call.method) {
+        NSDictionary *args = call.arguments;
+        NSNumber *enableNotifications = [args objectForKey:@"enableNotifications"];
+
+        if(enableNotifications) {
+            [self enableNotifications];
+        }
+    }
     if ([@"updateBadgeCount" isEqualToString:call.method]) {
         NSDictionary *args = call.arguments;
         NSNumber *count = [args objectForKey:@"count"];
+      
         if (@available(iOS 16, *)) {
             [[UNUserNotificationCenter currentNotificationCenter] setBadgeCount:count.integerValue withCompletionHandler:^(NSError * _Nullable error) {}];
         } else {

--- a/lib/flutter_app_badger.dart
+++ b/lib/flutter_app_badger.dart
@@ -38,19 +38,32 @@ class FlutterAppBadger {
     return appBadgeSupported ?? false;
   }
 
+  static Future<void> enableNotifications() async {
+    final mock = _mockEnableNotifications;
+    if (mock != null) {
+      await mock();
+      return;
+    }
+
+    return _channel.invokeMethod('enableNotifications');
+  }
+
   static Future<void> Function(int count)? _mockUpdateBadgeCount;
   static Future<void> Function()? _mockRemoveBadge;
   static Future<bool> Function()? _mockIsAppBadgeSupported;
+  static Future<bool> Function()? _mockEnableNotifications;
 
   @visibleForTesting
   static void setMocks({
     Future<void> Function(int count)? updateBadgeCount,
     Future<void> Function()? removeBadge,
     Future<bool> Function()? isAppBadgeSupported,
+    Future<bool> Function()? enableNotifications,
   }) {
     _mockUpdateBadgeCount = updateBadgeCount;
     _mockRemoveBadge = removeBadge;
     _mockIsAppBadgeSupported = isAppBadgeSupported;
+    _mockEnableNotifications = enableNotifications;
   }
 
   @visibleForTesting
@@ -58,5 +71,6 @@ class FlutterAppBadger {
     _mockUpdateBadgeCount = null;
     _mockRemoveBadge = null;
     _mockIsAppBadgeSupported = null;
+    _mockEnableNotifications = null;
   }
 }


### PR DESCRIPTION
### Description
- Create a separate method call for enabling push notification permission
- Prevent the plugin from calling `enableNotifications` by default when sending *any* method call

### Tickets
- Fixes #102
- Fixes #64